### PR TITLE
Create tests import method

### DIFF
--- a/demo1.test.mjs
+++ b/demo1.test.mjs
@@ -1,0 +1,38 @@
+
+import { Tests, Test } from "./tests.mjs";
+import assert from "node:assert";
+
+Array.prototype.lastIndexOf = function (element) {
+  for (let i = this.length - 1; i >= 0; i--) {
+    if (this[i] === element) return i;
+  }
+  return -1;
+}
+
+Array.prototype.findLastIndex = function (compare) {
+  for (let i = this.length - 1; i >= 0; i--) {
+    if (compare(this[i])) return i;
+  }
+  return -1;
+}
+
+export default [
+  Tests("core",
+    Tests("Array",
+      Test("#lastIndexOf", () => {
+        const arr = [5,2,3,2,1];
+        assert.equal(arr.lastIndexOf(2), 3);
+        assert.equal(arr.lastIndexOf(5), 0);
+        assert.equal(arr.lastIndexOf(4), -1);
+      }),
+      Test("#findLastIndex", () => {
+        const arr = [5,2,3,2,1];
+        const euqals = number => element => element === number;
+        assert.equal(arr.findLastIndex(euqals(2)), 3);
+        assert.equal(arr.findLastIndex(euqals(5)), 0);
+        assert.equal(arr.findLastIndex(euqals(4)), -1);
+      })
+    )
+  )
+]
+

--- a/importer.mjs
+++ b/importer.mjs
@@ -1,0 +1,73 @@
+import fs from "node:fs/promises";
+import assert from "node:assert";
+import vm from "node:vm";
+import module from "node:module";
+
+//  input: "string" relative path
+//  output: (Tree of) Test | Tests
+export async function readTests(file) {
+  const importMap = new Map();
+  const context = vm.createContext({}, { name: file });
+  const link = linker(importMap, context);
+
+  const vModule = await importModule(file, context, link);
+
+  await vModule.evaluate() // may be unnecessary
+  // https://nodejs.org/api/vm.html#modulenamespace
+
+  return vModule.namespace.default
+}
+
+function parseImport(name) {
+  // TODO: use path to make sure don't import relatevely-imported modules twice
+  if (name.includes(":")) {
+    return name.split(":")[1];
+  }
+  return name;
+}
+
+function linker(importMap, context) {
+  return async function link(specifier, referencingModule, { assertions }) {
+    const name = parseImport(specifier);
+    let mod = importMap.get(name);
+    if (!mod) {
+      mod = await (module.builtinModules.includes(name) ? importNative(name, context) : importModule(name, context, link));
+      importMap.set(name, mod);
+    }
+    return mod;
+  }
+}
+
+async function importNative(specifier, context) {
+  const rModule = await import(specifier)
+  const sModule = new vm.SyntheticModule(Object.keys(rModule),
+    function evaluateSelf () {
+      // may be unnecessary if readTests does not evaluate
+      Object.entries(rModule)
+      .forEach(entry => this.setExport(...entry));
+    }, {
+      identifier: `synthetic module "${specifier}"`,
+      context
+    }
+  )
+
+  return sModule;
+}
+
+async function importModule(specifier, context, link) {
+  const sourceText = await fs.readFile(`${process.cwd()}/${specifier}`, "utf-8");
+  const vModule = new vm.SourceTextModule(sourceText, {
+    identifier: `test case module for "${specifier}"`,
+    context,
+    initializeImportMeta(meta, module) {
+      meta["isTesting"] = true;
+    },
+    // assuming a promise can be returned. If not... well fk
+    importModuleDynamically: link
+  });
+
+  await vModule.link(link);
+
+  return vModule;
+}
+

--- a/package.json
+++ b/package.json
@@ -3,8 +3,9 @@
   "version": "1.0.4",
   "description": "A very simple framework for unit tests",
   "main": "main.mjs",
+  "bin": "test.mjs",
   "scripts": {
-    "test": "node test.mjs . --experimental-vm-modules"
+    "test": "./test.mjs ."
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A very simple framework for unit tests",
   "main": "main.mjs",
   "scripts": {
-    "test": "node test.mjs ."
+    "test": "node test.mjs . --experimental-vm-modules"
   },
   "repository": {
     "type": "git",

--- a/test.mjs
+++ b/test.mjs
@@ -1,4 +1,4 @@
-#!/usr/bin/env node
+#!/usr/bin/env node --experimental-vm-modules
 
 import { test } from "./tester.mjs";
 test(process.argv);

--- a/tester.mjs
+++ b/tester.mjs
@@ -68,10 +68,20 @@ export async function test(args) {
   output: (Tree of) Test | Tests
 */ async function readTests ( file ) {
 
+  let nativeModules = readTests.NATIVE_MODULES
+  let subsequentModules = new Map
+
   let sourceText = await fs.readFile(`${process.cwd()}/${file}`)
   let context = vm.createContext({  })
   let vModule = new vm.SourceTextModule( sourceText, {
-
+    identifier: `test case module for ./${file}`,
+    initializeImportMeta ( meta, module ) {
+      meta["isTesting"] = true 
+    },
+    importModuleDynamically ( specifier, module, importAssertions ) {
+ 
+    },
+    context,
   })
 
   await vModule.link(( specifier, referencingModule,{ assertions }) => {
@@ -83,6 +93,8 @@ export async function test(args) {
 
   return vModule.namespace.default
 }
+
+readTests["NATIVE_MODULES"] = new Map
 
 async function exec(testCases, scope, depth = 1, currentLog = logger(0), results = { failed: [] }) {
   for (let testCase of testCases) {

--- a/tester.mjs
+++ b/tester.mjs
@@ -21,18 +21,19 @@
  */
 
 import fs from "node:fs/promises";
-import assert from "node:assert"
-import vm from "node:vm"
-import module from "node:module"
+import vm from "node:vm";
+import { readTests } from "./importer.mjs";
 
 function logger(scoped) {
   return (message) => console.log("\t".repeat(scoped) + message);
 }
 
 export async function test(args) {
-  const [node, path, dirpath, filePath, ...flags] = args;
-  
-  assert.ok( flags.includes( "--experimental-vm-modules" ) )
+  const [node, path, dirpath, filePath] = args;
+
+  if (!vm.SyntheticModule) {
+    console.log("you suck!");
+  }
 
   const files = filePath ? [filePath] : await readDir(dirpath, /\.test\./);
 
@@ -44,10 +45,10 @@ export async function test(args) {
 
   for (let file of files) {
     try {
-      const testCases = await readTests( file );
+      const testCases = await readTests(file);
       console.log("_".repeat(96));
       console.log("\x1b[36m%s\x1b[0m", `\t${file}`);
-      const { failed } = await exec(testCases, file);
+      const { failed } = await exec(Array.from(testCases), file);
       failures = failures.concat(failed);
     }
     catch(e) {
@@ -65,77 +66,10 @@ export async function test(args) {
   }
 }
 
-/* input: "string" relative path
-  output: (Tree of) Test | Tests
-*/ async function readTests ( file ) {
-
-  let importer = new Importer
-  let vModule = importer.create_module( file )
-
-  await vModule.link( importer.get_or_create.bind( importer ) )
-  
-  // await vModule.evaluate() // may be unnecessary
-  // https://nodejs.org/api/vm.html#modulenamespace
-
-  return vModule.namespace.default
-}
-
-class Importer {
-
-  loadedModules = new Map
-  
-  async get_or_create ( specifier, referencingModule,{ assertions }) {
-    return Importer.NATIVE_MODULES.get(specifier)
-      ??
-      this.loadedModules.get(specifier)
-      ?? 
-      await this.create_module(specifier)
-  }
-  
-  async create_module ( specifier ) {
- 
-    let sourceText = await fs.readFile(`${process.cwd()}/${specifier}`)
- 
-    let vModule = new vm.SourceTextModule( sourceText, {
-      identifier: `test case module for "${specifier}"`,
-      context: Importer.CONTEXT,
-      initializeImportMeta ( meta, module ) {
-        meta["isTesting"] = true 
-      },
-      // assuming a promise can be returned. If not... well fk
-      importModuleDynamically: this.get_or_create.bind( this ),
-    })
-
-    this.loadedModules.set( specifier, vModule )
-  
-    return vModule
-  }
-
-  static CONTEXT = vm.createContext({},{
-    name: `Tests' Context`
-  })
-  static NATIVE_MODULES = new Map( await Promise.all( module.builtinModules().map( async specifier => {
-  
-    let rModule = await import(specifier)
-    let sModule = new vm.SyntheticModule(
-      Object.keys( rModule ), function evaluateSelf () {
-      // may be unnecessary if readTests does not evaluate 
-      Object.entries(rModule)
-        .forEach( entry => this.setExport( ...entry ) )
-    }, {
-      identifier: `synthetic module "${specifier}"`,
-      context: Importer.CONTEXT
-    })
-
-    return [ specifier, sModule ]
-  } ) ) )
-  
-}
-
 async function exec(testCases, scope, depth = 1, currentLog = logger(0), results = { failed: [] }) {
   for (let testCase of testCases) {
     const log = logger(depth);
-    if (testCase instanceof Array) {
+    if (Array.isArray(testCase)) {
       currentLog(`🧪 ${testCase.name}`);
       await exec(testCase, scope + ` -> ${testCase.name}`, depth + 1, log, results);
       continue;

--- a/tester.mjs
+++ b/tester.mjs
@@ -21,13 +21,16 @@
  */
 
 import fs from "fs/promises";
+import assert from "node:assert"
 
 function logger(scoped) {
   return (message) => console.log("\t".repeat(scoped) + message);
 }
 
 export async function test(args) {
-  const [node, path, dirpath, filePath] = args;
+  const [node, path, dirpath, filePath, ...flags] = args;
+  
+  assert.ok( flags.includes( "--experimental-vm-modules" ) )
 
   const files = filePath ? [filePath] : await readDir(dirpath, /\.test\./);
 

--- a/tester.mjs
+++ b/tester.mjs
@@ -20,8 +20,9 @@
  *
  */
 
-import fs from "fs/promises";
+import fs from "node:fs/promises";
 import assert from "node:assert"
+import vm from "node:vm"
 
 function logger(scoped) {
   return (message) => console.log("\t".repeat(scoped) + message);
@@ -67,7 +68,20 @@ export async function test(args) {
   output: (Tree of) Test | Tests
 */ async function readTests ( file ) {
 
- return (await import(`${process.cwd()}/${file}`)).default
+  let sourceText = await fs.readFile(`${process.cwd()}/${file}`)
+  let context = vm.createContext({  })
+  let vModule = new vm.SourceTextModule( sourceText, {
+
+  })
+
+  await vModule.link(( specifier, referencingModule,{ assertions }) => {
+
+  })
+  
+  // await vModule.evaluate() // may be unnecessary
+  // https://nodejs.org/api/vm.html#modulenamespace
+
+  return vModule.namespace.default
 }
 
 async function exec(testCases, scope, depth = 1, currentLog = logger(0), results = { failed: [] }) {

--- a/tester.mjs
+++ b/tester.mjs
@@ -42,7 +42,7 @@ export async function test(args) {
 
   for (let file of files) {
     try {
-      const testCases = (await import(`${process.cwd()}/${file}`)).default;
+      const testCases = await readTests( file );
       console.log("_".repeat(96));
       console.log("\x1b[36m%s\x1b[0m", `\t${file}`);
       const { failed } = await exec(testCases, file);
@@ -61,6 +61,13 @@ export async function test(args) {
   else {
     console.log("\n\x1b[32m%s\x1b[0m", `\t\t ✅|All Tests Passed|✅`)
   }
+}
+
+/* input: "string" relative path
+  output: (Tree of) Test | Tests
+*/ async function readTests ( file ) {
+
+ return (await import(`${process.cwd()}/${file}`)).default
 }
 
 async function exec(testCases, scope, depth = 1, currentLog = logger(0), results = { failed: [] }) {
@@ -91,3 +98,5 @@ async function readDir(path, pattern) {
   .filter(file => pattern.test(file))
   .map(file => `${path}/${file}`);
 }
+
+


### PR DESCRIPTION
Untested alternative to importing/reading tests. 
Could fix the issue of ambiguous errors thrown from within test cases.
However, custom/explicit diagnostic messages should be reported using the life cycles and properties the the VM api.

Furthermore, other designs can be explored by using custom imports or global scopes.